### PR TITLE
Add transfer indexer

### DIFF
--- a/server/db/migrate.ts
+++ b/server/db/migrate.ts
@@ -25,7 +25,7 @@ async function main() {
 async function ensureDatabaseExists(databaseUrl: string) {
   const url = new URL(databaseUrl);
   const databaseName = url.pathname.slice(1);
-  url.pathname = '';
+  url.pathname = 'postgres';
 
   console.log(`Checking if database ${databaseName} exists at ${url.host}`);
   const pool = new Pool({ connectionString: url.toString() });

--- a/server/db/migrations.sql
+++ b/server/db/migrations.sql
@@ -138,3 +138,22 @@ BEGIN
 END
 $$;
 
+--
+
+DO $$
+DECLARE
+    migration_version INT := 6;
+    migration_comment TEXT := 'Add owner to noun table and attributes optional';
+BEGIN
+    IF (SELECT MAX(version) FROM migrations) < migration_version THEN
+        RAISE NOTICE '%', migration_comment;
+        ALTER TABLE "public"."noun" ADD COLUMN "owner" text;
+        ALTER TABLE "public"."noun" ALTER COLUMN "background" DROP NOT NULL;
+        ALTER TABLE "public"."noun" ALTER COLUMN "body" DROP NOT NULL;
+        ALTER TABLE "public"."noun" ALTER COLUMN "accessory" DROP NOT NULL;
+        ALTER TABLE "public"."noun" ALTER COLUMN "head" DROP NOT NULL;
+        ALTER TABLE "public"."noun" ALTER COLUMN "glasses" DROP NOT NULL;
+        INSERT INTO migrations (version, comment) VALUES (migration_version, migration_comment);
+    END IF;
+END
+$$;

--- a/server/db/queries.ts
+++ b/server/db/queries.ts
@@ -28,6 +28,31 @@ const getAuctionLastQueriedBlockIR: any = {"usedParamSet":{},"params":[],"statem
 export const getAuctionLastQueriedBlock = new PreparedQuery<IGetAuctionLastQueriedBlockParams,IGetAuctionLastQueriedBlockResult>(getAuctionLastQueriedBlockIR);
 
 
+/** 'GetTransferLastQueriedBlock' parameters type */
+export type IGetTransferLastQueriedBlockParams = void;
+
+/** 'GetTransferLastQueriedBlock' return type */
+export interface IGetTransferLastQueriedBlockResult {
+  value: number | null;
+}
+
+/** 'GetTransferLastQueriedBlock' query type */
+export interface IGetTransferLastQueriedBlockQuery {
+  params: IGetTransferLastQueriedBlockParams;
+  result: IGetTransferLastQueriedBlockResult;
+}
+
+const getTransferLastQueriedBlockIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT \"value\" FROM \"state\" WHERE \"key\" = 'transfer_last_queried_block' LIMIT 1"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT "value" FROM "state" WHERE "key" = 'transfer_last_queried_block' LIMIT 1
+ * ```
+ */
+export const getTransferLastQueriedBlock = new PreparedQuery<IGetTransferLastQueriedBlockParams,IGetTransferLastQueriedBlockResult>(getTransferLastQueriedBlockIR);
+
+
 /** 'SetAuctionLastQueriedBlock' parameters type */
 export interface ISetAuctionLastQueriedBlockParams {
   lastBlockNumber: number;
@@ -54,6 +79,34 @@ const setAuctionLastQueriedBlockIR: any = {"usedParamSet":{"lastBlockNumber":tru
  * ```
  */
 export const setAuctionLastQueriedBlock = new PreparedQuery<ISetAuctionLastQueriedBlockParams,ISetAuctionLastQueriedBlockResult>(setAuctionLastQueriedBlockIR);
+
+
+/** 'SetTransferLastQueriedBlock' parameters type */
+export interface ISetTransferLastQueriedBlockParams {
+  lastBlockNumber: number;
+}
+
+/** 'SetTransferLastQueriedBlock' return type */
+export type ISetTransferLastQueriedBlockResult = void;
+
+/** 'SetTransferLastQueriedBlock' query type */
+export interface ISetTransferLastQueriedBlockQuery {
+  params: ISetTransferLastQueriedBlockParams;
+  result: ISetTransferLastQueriedBlockResult;
+}
+
+const setTransferLastQueriedBlockIR: any = {"usedParamSet":{"lastBlockNumber":true},"params":[{"name":"lastBlockNumber","required":true,"transform":{"type":"scalar"},"locs":[{"a":76,"b":92},{"a":174,"b":190}]}],"statement":"INSERT INTO \"state\" (\"key\", \"value\")\nVALUES ('transfer_last_queried_block', :lastBlockNumber!::INTEGER)\nON CONFLICT (\"key\") DO UPDATE SET\n\"value\" = GREATEST(\"state\".\"value\", :lastBlockNumber!::INTEGER)"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO "state" ("key", "value")
+ * VALUES ('transfer_last_queried_block', :lastBlockNumber!::INTEGER)
+ * ON CONFLICT ("key") DO UPDATE SET
+ * "value" = GREATEST("state"."value", :lastBlockNumber!::INTEGER)
+ * ```
+ */
+export const setTransferLastQueriedBlock = new PreparedQuery<ISetTransferLastQueriedBlockParams,ISetTransferLastQueriedBlockResult>(setTransferLastQueriedBlockIR);
 
 
 /** 'FindBidsWithMissingTransactions' parameters type */
@@ -126,8 +179,8 @@ export interface IFindUnindexedWalletsParams {
 
 /** 'FindUnindexedWallets' return type */
 export interface IFindUnindexedWalletsResult {
-  address: string;
-  auctionId: number;
+  address: string | null;
+  auctionId: number | null;
 }
 
 /** 'FindUnindexedWallets' query type */
@@ -136,15 +189,32 @@ export interface IFindUnindexedWalletsQuery {
   result: IFindUnindexedWalletsResult;
 }
 
-const findUnindexedWalletsIR: any = {"usedParamSet":{"limit":true},"params":[{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":195,"b":201}]}],"statement":"SELECT \"bid\".\"auctionId\", \"bid\".\"walletAddress\" as \"address\"\nFROM \"bid\"\nLEFT JOIN \"wallet\" ON \"bid\".\"walletAddress\" = \"wallet\".\"address\"\nWHERE \"ens\" IS NULL ORDER BY \"bid\".\"auctionId\" DESC LIMIT :limit!::INTEGER"};
+const findUnindexedWalletsIR: any = {"usedParamSet":{"limit":true},"params":[{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":494,"b":500}]}],"statement":"(\n  SELECT \n    \"bid\".\"auctionId\", \n    \"bid\".\"walletAddress\" as \"address\" \n  FROM \"bid\" \n  LEFT JOIN \"wallet\" \n    ON \"bid\".\"walletAddress\" = \"wallet\".\"address\" \n  WHERE \"wallet\".\"ens\" IS NULL AND \"bid\".\"walletAddress\" IS NOT NULL\n)\nUNION\n(\n  SELECT \n    NULL as \"auctionId\",\n    \"noun\".\"owner\" as \"address\"\n  FROM \"noun\"\n  LEFT JOIN \"wallet\"\n    ON \"noun\".\"owner\" = \"wallet\".\"address\"\n  WHERE \"wallet\".\"ens\" IS NULL AND \"noun\".\"owner\" IS NOT NULL\n)\nORDER BY \"auctionId\" DESC NULLS LAST\nLIMIT :limit!::INTEGER"};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT "bid"."auctionId", "bid"."walletAddress" as "address"
- * FROM "bid"
- * LEFT JOIN "wallet" ON "bid"."walletAddress" = "wallet"."address"
- * WHERE "ens" IS NULL ORDER BY "bid"."auctionId" DESC LIMIT :limit!::INTEGER
+ * (
+ *   SELECT 
+ *     "bid"."auctionId", 
+ *     "bid"."walletAddress" as "address" 
+ *   FROM "bid" 
+ *   LEFT JOIN "wallet" 
+ *     ON "bid"."walletAddress" = "wallet"."address" 
+ *   WHERE "wallet"."ens" IS NULL AND "bid"."walletAddress" IS NOT NULL
+ * )
+ * UNION
+ * (
+ *   SELECT 
+ *     NULL as "auctionId",
+ *     "noun"."owner" as "address"
+ *   FROM "noun"
+ *   LEFT JOIN "wallet"
+ *     ON "noun"."owner" = "wallet"."address"
+ *   WHERE "wallet"."ens" IS NULL AND "noun"."owner" IS NOT NULL
+ * )
+ * ORDER BY "auctionId" DESC NULLS LAST
+ * LIMIT :limit!::INTEGER
  * ```
  */
 export const findUnindexedWallets = new PreparedQuery<IFindUnindexedWalletsParams,IFindUnindexedWalletsResult>(findUnindexedWalletsIR);
@@ -307,7 +377,13 @@ export interface IFindUnindexedNounsParams {
 
 /** 'FindUnindexedNouns' return type */
 export interface IFindUnindexedNounsResult {
+  accessory: number | null;
+  background: number | null;
+  body: number | null;
+  glasses: number | null;
+  head: number | null;
   id: number;
+  owner: string | null;
 }
 
 /** 'FindUnindexedNouns' query type */
@@ -316,17 +392,12 @@ export interface IFindUnindexedNounsQuery {
   result: IFindUnindexedNounsResult;
 }
 
-const findUnindexedNounsIR: any = {"usedParamSet":{"limit":true},"params":[{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":152}]}],"statement":"SELECT \"auction\".\"id\" as \"id\"\nFROM \"auction\"\nLEFT JOIN \"noun\" ON \"auction\".\"id\" = \"noun\".\"id\"\nWHERE \"background\" IS NULL\nORDER BY \"id\" DESC\nLIMIT :limit!::INTEGER"};
+const findUnindexedNounsIR: any = {"usedParamSet":{"limit":true},"params":[{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":73,"b":79}]}],"statement":"SELECT * FROM \"noun\" WHERE \"background\" IS NULL ORDER BY \"id\" DESC LIMIT :limit!::INTEGER"};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT "auction"."id" as "id"
- * FROM "auction"
- * LEFT JOIN "noun" ON "auction"."id" = "noun"."id"
- * WHERE "background" IS NULL
- * ORDER BY "id" DESC
- * LIMIT :limit!::INTEGER
+ * SELECT * FROM "noun" WHERE "background" IS NULL ORDER BY "id" DESC LIMIT :limit!::INTEGER
  * ```
  */
 export const findUnindexedNouns = new PreparedQuery<IFindUnindexedNounsParams,IFindUnindexedNounsResult>(findUnindexedNounsIR);
@@ -367,6 +438,35 @@ const updateNounSeedsIR: any = {"usedParamSet":{"id":true,"background":true,"bod
  * ```
  */
 export const updateNounSeeds = new PreparedQuery<IUpdateNounSeedsParams,IUpdateNounSeedsResult>(updateNounSeedsIR);
+
+
+/** 'UpdateNounOwner' parameters type */
+export interface IUpdateNounOwnerParams {
+  id: number;
+  owner: string;
+}
+
+/** 'UpdateNounOwner' return type */
+export type IUpdateNounOwnerResult = void;
+
+/** 'UpdateNounOwner' query type */
+export interface IUpdateNounOwnerQuery {
+  params: IUpdateNounOwnerParams;
+  result: IUpdateNounOwnerResult;
+}
+
+const updateNounOwnerIR: any = {"usedParamSet":{"id":true,"owner":true},"params":[{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":43,"b":46}]},{"name":"owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":49,"b":55},{"a":103,"b":109}]}],"statement":"INSERT INTO \"noun\" (\"id\", \"owner\")\nVALUES (:id!, :owner!)\nON CONFLICT (\"id\") DO UPDATE SET\n  \"owner\" = :owner!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO "noun" ("id", "owner")
+ * VALUES (:id!, :owner!)
+ * ON CONFLICT ("id") DO UPDATE SET
+ *   "owner" = :owner!
+ * ```
+ */
+export const updateNounOwner = new PreparedQuery<IUpdateNounOwnerParams,IUpdateNounOwnerResult>(updateNounOwnerIR);
 
 
 /** 'TotalNounsSupply' parameters type */
@@ -488,12 +588,13 @@ export interface IGetNounByIdParams {
 
 /** 'GetNounById' return type */
 export interface IGetNounByIdResult {
-  accessory: number;
-  background: number;
-  body: number;
-  glasses: number;
-  head: number;
+  accessory: number | null;
+  background: number | null;
+  body: number | null;
+  glasses: number | null;
+  head: number | null;
   id: number;
+  owner: string | null;
 }
 
 /** 'GetNounById' query type */

--- a/server/indexers/transfers.ts
+++ b/server/indexers/transfers.ts
@@ -1,0 +1,95 @@
+import 'dotenv/config';
+import { ContractEventPayload, ethers } from 'ethers';
+import { NounsToken__factory } from '../../typechain';
+import { logger } from '../utils';
+import { PoolClient } from 'pg';
+import {
+  getTransferLastQueriedBlock,
+  setTransferLastQueriedBlock,
+  updateNounOwner,
+} from '../db/queries';
+import { TransferEvent } from '../../typechain/NounsToken';
+
+type NounsTokenEventLog = TransferEvent.Log;
+
+const log = logger.child({ indexer: 'transfer' });
+
+export default async function transfers(
+  nounAddress: string,
+  connection: PoolClient,
+  provider: ethers.Provider,
+) {
+  log.info('Starting');
+  const nouns = NounsToken__factory.connect(nounAddress, provider);
+
+  async function maybeProcessEvent(event: NounsTokenEventLog) {
+    try {
+      log.debug('Processing event %s', event.eventName, { event });
+      processEvent(connection, event);
+    } catch (error) {
+      log.error(error);
+    }
+  }
+
+  nouns.on(nouns.filters.Transfer(), (...args) => {
+    // Ethers: the first N arguments are event args verbatim
+    // The event object we care about is the last argument
+    const payload = args[args.length - 1] as unknown as ContractEventPayload;
+
+    maybeProcessEvent(payload.log as unknown as NounsTokenEventLog);
+  });
+
+  const result = await getTransferLastQueriedBlock.run(undefined, connection);
+
+  const lastQueriedBlock = result[0]?.value || 12985450; // Nouns Deployment -1
+  let lastBlockNumber = lastQueriedBlock;
+
+  log.debug('Loaded state', { lastQueriedBlock });
+  const currentBlockNumber = await provider.getBlockNumber();
+  const limit = 1_000_000;
+  const pages = Math.ceil((currentBlockNumber - lastQueriedBlock) / limit);
+
+  for (let page = 0; page <= pages; page += 1) {
+    const blockFrom = lastQueriedBlock + page * limit + 1;
+    const blockTo = Math.min(currentBlockNumber, lastQueriedBlock + (page + 1) * limit);
+    if (blockFrom > currentBlockNumber) {
+      break;
+    }
+
+    log.debug('Querying events', { blockFrom, blockTo });
+    const events: Array<NounsTokenEventLog> = await nouns.queryFilter(
+      nouns.filters.Transfer(),
+      blockFrom,
+      blockTo,
+    );
+
+    for (const event of events) {
+      await maybeProcessEvent(event);
+      lastBlockNumber = Math.max(lastBlockNumber, event.blockNumber);
+    }
+
+    await setTransferLastQueriedBlock.run({ lastBlockNumber }, connection);
+  }
+
+  // Wait forever, otherwise the connection is released and the event handlers
+  // won't be able to run SQL
+  await new Promise((resolve) => {});
+}
+
+async function processEvent(connection: PoolClient, eventLog: NounsTokenEventLog) {
+  if (eventLog.eventName === 'Transfer') {
+    const { to, tokenId } = (eventLog as TransferEvent.Log).args;
+
+    await updateNounOwner.run(
+      {
+        id: Number(tokenId),
+        owner: to.toLowerCase(),
+      },
+      connection,
+    );
+
+    return;
+  }
+
+  log.warn('Nothing to do for this event', { event: eventLog });
+}

--- a/server/indexers/wallets.ts
+++ b/server/indexers/wallets.ts
@@ -28,7 +28,7 @@ export default async function wallets(
 
     //TODO: Make resolver for ens
     const ens = await Promise.all(
-      wallets.map((row) => provider.lookupAddress(row.address).catch(() => null)),
+      wallets.map((row) => provider.lookupAddress(row.address || '').catch(() => null)),
     );
     const balancesNouns = await Promise.all(wallets.map((row) => nouns.balanceOf(row.address)));
 
@@ -37,7 +37,7 @@ export default async function wallets(
     for (const [index, row] of wallets.entries()) {
       await updateWalletData.run(
         {
-          address: row.address,
+          address: row.address || '',
           ens: ens[index] || '',
           nouns: balancesNouns[index].toString(),
         },

--- a/server/start.ts
+++ b/server/start.ts
@@ -16,6 +16,7 @@ import { Pool, PoolClient } from 'pg';
 import nouns from './indexers/nouns';
 import { getLatestAuction } from './db/queries';
 import balances from './indexers/balances';
+import transfers from './indexers/transfers';
 
 async function main() {
   const port = parseInt(process.env.PORT || '3003', 10);
@@ -89,6 +90,7 @@ async function main() {
     withPgClient((connection) => nouns(NOUNS_TOKEN_ADDRESS, connection, provider)),
     withPgClient((connection) => transactions(connection, provider)),
     withPgClient((connection) => balances(connection, provider)),
+    withPgClient((connection) => transfers(NOUNS_TOKEN_ADDRESS, connection, provider)),
   ]);
 }
 


### PR DESCRIPTION
1. Add the new queries `getTransferLastQueriedBlock`, `setTransferLastQueriedBlock`, `insertNounOwnerInAuction`, and `insertWallet`
2. Add a new indexer/listener called `transfers` 
3. Rewrite the `insertAuction` query to resolve conflicts, as `auction` and `transfers` impact the same table simultaneously