### PR TITLE
Add extra check for `nounProperties`

### DIFF
--- a/components/AuctionHeader.tsx
+++ b/components/AuctionHeader.tsx
@@ -29,7 +29,7 @@ type Props = {
   ownerAddress: string | null;
   noun: Noun | null;
   onSubmitBid: (bid: PendingBid) => unknown;
-  nounProperties: NounProperty[] | null;
+  nounProperties: NounProperty[];
 };
 
 const abi = [

--- a/components/NounInfo.tsx
+++ b/components/NounInfo.tsx
@@ -12,12 +12,12 @@ export default function NounInfo({
   owner,
 }: {
   noun: Noun | null;
-  nounProperties: NounProperty[] | null;
+  nounProperties: NounProperty[];
   nounSrc: string;
   winner: string;
   owner: string;
 }) {
-  if (!noun || !nounProperties) {
+  if (!noun || nounProperties.length >= 4) {
     return null;
   }
 


### PR DESCRIPTION
I reproduced the issue in the local environment and discovered that a noun has an ID and an owner after the [settleCurrentAndCreateNewAuction](https://etherscan.io/address/0x830bd73e4184cef73443c15111a1df14e495c706#writeProxyContract) triggers. The transfer indexer inserts the ID and owner of a new noun in the database, but other values are undefined. If we put a noun with all properties undefined in the `getNounData` method, we receive an array with undefined values and start going through an empty array, resulting in an error. To fix this issue, I added a check to ensure that we have all the necessary properties in the `nounProperties` array. Additionally, our array of `nounProperties` always exists, so I removed null from the types.