### PR TITLE
Database indexer fix

### DIFF
--- a/server/db/queries.sql
+++ b/server/db/queries.sql
@@ -59,8 +59,9 @@ ON CONFLICT ("address") DO UPDATE SET
 /* @name insertAuction */
 INSERT INTO auction("id", "startTime", "endTime")
 VALUES (:id!, :startTime!, :endTime!)
-ON CONFLICT DO NOTHING;
-
+ON CONFLICT ("id") DO UPDATE SET
+  "startTime" = EXCLUDED."startTime",
+  "endTime" = EXCLUDED."endTime";
 
 /* @name updateAuctionExtended */
 UPDATE auction
@@ -68,9 +69,11 @@ SET "endTime" = GREATEST("auction"."endTime", :endTime::INTEGER)
 WHERE auction.id = :id!;
 
 /* @name updateAuctionSettled */
-UPDATE auction
-SET "winner" = :winner!, "price" = :price!
-WHERE auction.id = :id!;
+INSERT INTO auction("id", "startTime", "endTime", "winner", "price")
+VALUES (:id!, 0, 0, :winner!, :price!)
+ON CONFLICT ("id") DO UPDATE SET
+  "winner" = EXCLUDED."winner",
+  "price" = EXCLUDED."price";
 
 /* @name insertAuctionBid */
 INSERT INTO bid("tx", "index", "auctionId", "walletAddress", "value", "maxFeePerGas", "block", "extended")

--- a/server/db/queries.ts
+++ b/server/db/queries.ts
@@ -322,14 +322,16 @@ export interface IUpdateAuctionSettledQuery {
   result: IUpdateAuctionSettledResult;
 }
 
-const updateAuctionSettledIR: any = {"usedParamSet":{"winner":true,"price":true,"id":true},"params":[{"name":"winner","required":true,"transform":{"type":"scalar"},"locs":[{"a":30,"b":37}]},{"name":"price","required":true,"transform":{"type":"scalar"},"locs":[{"a":50,"b":56}]},{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":77,"b":80}]}],"statement":"UPDATE auction\nSET \"winner\" = :winner!, \"price\" = :price!\nWHERE auction.id = :id!"};
+const updateAuctionSettledIR: any = {"usedParamSet":{"id":true,"winner":true,"price":true},"params":[{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":77,"b":80}]},{"name":"winner","required":true,"transform":{"type":"scalar"},"locs":[{"a":89,"b":96}]},{"name":"price","required":true,"transform":{"type":"scalar"},"locs":[{"a":99,"b":105}]}],"statement":"INSERT INTO auction(\"id\", \"startTime\", \"endTime\", \"winner\", \"price\")\nVALUES (:id!, 0, 0, :winner!, :price!)\nON CONFLICT (\"id\") DO UPDATE SET\n  \"winner\" = EXCLUDED.\"winner\",\n  \"price\" = EXCLUDED.\"price\""};
 
 /**
  * Query generated from SQL:
  * ```
- * UPDATE auction
- * SET "winner" = :winner!, "price" = :price!
- * WHERE auction.id = :id!
+ * INSERT INTO auction("id", "startTime", "endTime", "winner", "price")
+ * VALUES (:id!, 0, 0, :winner!, :price!)
+ * ON CONFLICT ("id") DO UPDATE SET
+ *   "winner" = EXCLUDED."winner",
+ *   "price" = EXCLUDED."price"
  * ```
  */
 export const updateAuctionSettled = new PreparedQuery<IUpdateAuctionSettledParams,IUpdateAuctionSettledResult>(updateAuctionSettledIR);

--- a/server/getAuctionData.ts
+++ b/server/getAuctionData.ts
@@ -11,6 +11,7 @@ import {
 import { AuctionData, Bid } from './api/types';
 
 const liveCache = new Map();
+const pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 export function getLiveAuctionData(id?: number | null): LiveQuery<AuctionData> {
   if (!liveCache.has(id)) {
@@ -24,8 +25,6 @@ export function getLiveAuctionData(id?: number | null): LiveQuery<AuctionData> {
 }
 
 export default async function getAuctionData(id?: number | null) {
-  const pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
-
   if (id == null) {
     const [res] = await getLatestAuctionId.run({ offset: 0 }, pgPool);
     id = res.id;

--- a/server/indexers/transfers.ts
+++ b/server/indexers/transfers.ts
@@ -63,7 +63,11 @@ export default async function transfers(
       blockTo,
     );
 
-    for (const event of events) {
+    const sortedEvents = events
+      .flat()
+      .sort((a, b) => a.blockNumber - b.blockNumber || a.index - b.index);
+
+    for (const event of sortedEvents) {
       await maybeProcessEvent(event);
       lastBlockNumber = Math.max(lastBlockNumber, event.blockNumber);
     }


### PR DESCRIPTION
1. When the user loads the auction, we create a new pool (error: sorry, too many clients already)
2. Sometimes the `AuctionCreated` event can fail, in this case we can't update the winner and price
3. The transfer indexer can update the wrong owner for the noun because the blocks aren't sorted